### PR TITLE
fix: get campus from institution role when there is no umich_hr data

### DIFF
--- a/lib/patron/employee.rb
+++ b/lib/patron/employee.rb
@@ -87,8 +87,8 @@ class Patron
     end
 
     def campus_code_from_inst_role
-      umichinstrole = @data["umichinstroles"].first { |x| inst_role_base.match?(x) }
-      Patron.inst_role_map.first { |x| x["key"] == umichinstrole }["campus"]
+      umichinstrole = @data["umichinstroles"].find { |x| x.match?(inst_role_base) }
+      Patron.inst_role_map.find { |x| x["key"] == umichinstrole }["campus"]
     end
   end
 end

--- a/spec/patron/faculty_spec.rb
+++ b/spec/patron/faculty_spec.rb
@@ -19,9 +19,9 @@ describe Patron::Faculty do
       expect(subject.campus_code).to eq("UMFL")
     end
     it "comes from first faculty matched inst role when not hr data" do
-      @patron["umichinstroles"].push("FacultyAA")
+      @patron["umichinstroles"][1] = "FacultyDBRN"
       @patron["umichhr"] = []
-      expect(subject.campus_code).to eq("UMAA")
+      expect(subject.campus_code).to eq("UMDB")
     end
   end
   context "#includable?" do


### PR DESCRIPTION
before this PR the code always returned UMAA as the campus for patrons without `umich_hr` info. Now the corresponding test exercises the problem, and the code actually parses the campus from the institution role.