### PR TITLE
add exclude reason when there are no valid institution roles

### DIFF
--- a/lib/patron.rb
+++ b/lib/patron.rb
@@ -44,6 +44,7 @@ class Patron
         exclude_reasons.push(user.exclude_reason)
       end
     end
+    exclude_reasons.push("no_valid_institution_role") if inst_roles.empty?
     Skipped.new(data: data, exclude_reasons: exclude_reasons)
   end
 


### PR DESCRIPTION
A user with NewHire as the only institution role is currently skipped, but the exclude reason isn't mentioned. This PR adds an exclude_reason for users with no valid institution roles